### PR TITLE
Skip installation of IBM Cloud CLI for aarch64 in devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,13 +24,17 @@ RUN groupadd --gid $USER_GID $USERNAME \
 WORKDIR /workspace
 
 # Add the IBM Cloud CLI
-RUN wget -O bluemix-cli.tar.gz https://clis.cloud.ibm.com/download/bluemix-cli/1.4.0/linux64 && \
-    tar xzf bluemix-cli.tar.gz && \
-    cd Bluemix_CLI/ && \
-    ./install && \
-    cd .. && \
-    rm -fr Bluemix_CLI/ bluemix-cli.tar.gz && \
-    ibmcloud cf install
+RUN if [ $(uname -m) != aarch64 ]; then \
+        wget -O bluemix-cli.tar.gz https://clis.cloud.ibm.com/download/bluemix-cli/1.4.0/linux64 && \
+        tar xzf bluemix-cli.tar.gz && \
+        cd Bluemix_CLI/ && \
+        ./install && \
+        cd .. && \
+        rm -fr Bluemix_CLI/ bluemix-cli.tar.gz && \
+        ibmcloud cf install; \
+    else \
+        echo "aarch64 not supported"; \
+    fi;
 
 # Establish Python dependencies
 COPY requirements.txt .


### PR DESCRIPTION
@rofrano 
Current Dockerfile will fail on Apple M1 machines, because of the installation of IBM Cloud CLI not supporting `aarch64`.
This PR fix the issue by skipping the scripts on `aarch64`

Should also apply to `lab-bluemix-cf` 😊