### PR TITLE
VS Code settings and tasks for dev containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,5 +15,7 @@
     	"wholroyd.jinja",
 		"github.vscode-pull-request-github"
 	],
-	"forwardPorts": [8080]
+	"forwardPorts": [8080],
+	// Create .env file if it doesn't exist
+	"postAttachCommand": "if [ ! -f /.env ]; then cp dot-env-example .env; fi; "
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
 		"donjayamanne.githistory",
     	"bbenoist.vagrant",
 		"cstrap.flask-snippets",
-    	"wholroyd.jinja"
+    	"wholroyd.jinja",
+		"github.vscode-pull-request-github"
 	],
 	"forwardPorts": [8080]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+.noseids
 coverage.xml
 *,cover
 .hypothesis/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-    "python.linting.pylintEnabled": true
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.testing.nosetestsEnabled": true,
+    "python.testing.nosetestArgs": ["-c=setup.cfg"],
+    "cucumberautocomplete.steps": ["features/steps/*.py"],
+    "cucumberautocomplete.syncfeatures": "features/*.feature",
+    "cucumberautocomplete.strictGherkinCompletion": true,
+    "cucumberautocomplete.strictGherkinValidation": true,
+    "cucumberautocomplete.smartSnippets": true,
+    "cucumberautocomplete.gherkinDefinitionPart": "@(given|when|then)\\(",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+// Test tasks for NYU course DevOps and Agile Methodologies taught by John Rofrano
+// Copyright Shuhong Cai 2021. Licensed under the Apache License, Version 2.0
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "TDD tests",
+            "type": "shell",
+            "command": "nosetests",
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated",
+            }
+        },
+        {
+            "label": "BDD tests",
+            "type": "shell",
+            "command": "honcho start >/dev/null 2>&1 & sleep 5 && behave; kill %%",
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated",
+            }
+        },
+        {
+            "label": "TDD & BDD tests",
+            "type": "shell",
+            "group": "test",
+            "dependsOrder": "sequence",
+            "dependsOn": ["TDD tests", "BDD tests"],
+            "presentation": {
+                "reveal": "never",
+            }
+        },
+    ]
+        
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 applications:
-- nme: lab-flask-bdd
+- name: lab-flask-bdd
   path: .
   instances: 2
   memory: 64M


### PR DESCRIPTION
Hi, @rofrano 

This PR configures the settings and tasks in .vscode to enable several functionalities in VS Code dev containers for `lab-flask-bdd`, including

- Linting highlight by `pylint` using VS Code Python extension (https://code.visualstudio.com/docs/python/linting)
- Run TDD tests by `nose` using VS Code Python extension (https://code.visualstudio.com/docs/python/testing)
- Run both TDD & BDD tests using VS Code Tasks (selecting tasks in Run Test Task from the Command Palette)

This PR also:
- fix a typo in `manifest.yml`
- copy the `dot-env-exmple` if `.env` does not exist