### PR TITLE
Typo in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,5 +18,5 @@
 	],
 	"forwardPorts": [8080],
 	// Create .env file if it doesn't exist
-	"postAttachCommand": "if [ ! -f /.env ]; then cp dot-env-example .env; fi; "
+	"postAttachCommand": "if [ ! -f .env ]; then cp dot-env-example .env; fi; "
 }


### PR DESCRIPTION
Hi, @rofrano 
I left an additional slash in `.devcontainer` in #13 , which will replace `.env` with `dot-env-example` even when `.env` exists. This PR removes it. Sorry for the mistake.
