### PR TITLE
Upgrade permissions and Codecov action and add installation step

### DIFF
--- a/.github/workflows/bdd-tests.yml
+++ b/.github/workflows/bdd-tests.yml
@@ -15,6 +15,10 @@ on:
     - '.vscode/**'
     - '**.md'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tdd-tests.yml
+++ b/.github/workflows/tdd-tests.yml
@@ -15,6 +15,10 @@ on:
     - '.vscode/**'
     - '**.md'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -61,7 +65,12 @@ jobs:
           FLASK_APP: "wsgi:app"
           DATABASE_URI: "postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/testdb"
 
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v3.1.4
-        with: 
+      - name: Install packages for Codecov to work
+        run: apt update && apt install -y git curl gpg
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: nyu-devops/lab-flask-bdd
+  


### PR DESCRIPTION
Made the following changes

- Updated the GitHub Action permissions to be explicit
- Updated Codecov action to v5
- Added package installation step for missing packages that CodeCov requires but does not document